### PR TITLE
[재고 상세 페이지] 스타일 및 버튼 실행

### DIFF
--- a/.github/workflows/type-check.yml
+++ b/.github/workflows/type-check.yml
@@ -1,4 +1,4 @@
-name: lint check
+name: type check
 
 on: pull_request
 

--- a/src/api/__mock__/product.ts
+++ b/src/api/__mock__/product.ts
@@ -2,6 +2,7 @@ import { ProductType } from '@/api/@types/@enums';
 
 interface MockSeller {
   id: number;
+  profile?: string;
   nickname: string;
   stockCount: number;
   reviewCount: number;
@@ -39,6 +40,7 @@ export const mockProductDetail: MockProductDetail = {
     '제가 LA에 있을때는 말이죠 정말 제가 꿈에 무대인 메이저리그로 진출해서 가는 식당마다 싸인해달라 기자들은 항상 붙어다니며 취재하고 제가 그 머~ 어~ 대통령이 된 기분이였어요 그런데 17일만에 17일만에 마이너리그로 떨어졌어요',
   seller: {
     id: 12,
+    profile: 'https://bit.ly/sage-adebayo',
     nickname: '우리동네LA형',
     stockCount: 5000,
     reviewCount: 0,

--- a/src/components/domains/products/ReservationButton.tsx
+++ b/src/components/domains/products/ReservationButton.tsx
@@ -1,0 +1,70 @@
+import { useState } from 'react';
+import {
+  Button,
+  Grid,
+  Link,
+  Modal,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+  ModalOverlay,
+  useDisclosure,
+} from '@chakra-ui/react';
+import { useCustomToast } from '@/hooks/useCustomToast';
+
+const ReservationButton = () => {
+  const [isReserved, setIsReserved] = useState<boolean>(false);
+  const { isOpen, onOpen, onClose } = useDisclosure();
+  const toast = useCustomToast();
+
+  const onReserve = () => {
+    setIsReserved(true);
+  };
+
+  const onlyReserve = () => {
+    toast.success('예약에 성공했어요!');
+  };
+
+  const cancelReserve = () => {
+    setIsReserved(false);
+    toast.info('예약 요청이 취소되었습니다.');
+  };
+  return (
+    <>
+      {!isReserved && (
+        <Grid p="1.2rem 0" onClick={onReserve}>
+          <Button colorScheme="brand" onClick={onOpen}>
+            구매 예약 요청하기
+          </Button>
+        </Grid>
+      )}
+      {isReserved && (
+        <Grid p="1.2rem 0">
+          <Button colorScheme="gray" onClick={cancelReserve}>
+            구매 예약 요청 취소하기
+          </Button>
+        </Grid>
+      )}
+      <Modal isOpen={isOpen} onClose={onClose}>
+        <ModalOverlay />
+        <ModalContent>
+          <ModalHeader>예약됐습니다😊 채팅으로 바로 이동할까요?</ModalHeader>
+
+          <ModalFooter>
+            <Button colorScheme="blue" mr={3} onClick={isOpen}>
+              <Link to="../">채팅하러 갈래요!</Link>
+            </Button>
+
+            <Grid onClick={onlyReserve}>
+              <Button variant="ghost" onClick={onClose}>
+                아니요. 예약만 할게요
+              </Button>
+            </Grid>
+          </ModalFooter>
+        </ModalContent>
+      </Modal>
+    </>
+  );
+};
+
+export default ReservationButton;

--- a/src/components/domains/products/ReservationButton.tsx
+++ b/src/components/domains/products/ReservationButton.tsx
@@ -1,13 +1,16 @@
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import {
   Button,
   Grid,
-  Link,
   Modal,
+  ModalBody,
+  ModalCloseButton,
   ModalContent,
   ModalFooter,
   ModalHeader,
   ModalOverlay,
+  Text,
   useDisclosure,
 } from '@chakra-ui/react';
 import { useCustomToast } from '@/hooks/useCustomToast';
@@ -16,19 +19,18 @@ const ReservationButton = () => {
   const [isReserved, setIsReserved] = useState<boolean>(false);
   const { isOpen, onOpen, onClose } = useDisclosure();
   const toast = useCustomToast();
+  const navigate = useNavigate();
 
   const onReserve = () => {
     setIsReserved(true);
-  };
-
-  const onlyReserve = () => {
     toast.success('예약에 성공했어요!');
   };
 
   const cancelReserve = () => {
     setIsReserved(false);
-    toast.info('예약 요청이 취소되었습니다.');
+    toast.info('예약이 취소되었어요.');
   };
+
   return (
     <>
       {!isReserved && (
@@ -45,21 +47,24 @@ const ReservationButton = () => {
           </Button>
         </Grid>
       )}
-      <Modal isOpen={isOpen} onClose={onClose}>
+      <Modal isOpen={isOpen} onClose={onClose} isCentered>
         <ModalOverlay />
         <ModalContent>
-          <ModalHeader>예약됐습니다😊 채팅으로 바로 이동할까요?</ModalHeader>
+          <ModalCloseButton />
 
-          <ModalFooter>
-            <Button colorScheme="blue" mr={3} onClick={isOpen}>
-              <Link to="../">채팅하러 갈래요!</Link>
+          <ModalHeader />
+          <ModalBody py={6}>
+            <Text textAlign="center">예약됐습니다😊 채팅으로 바로 이동할까요?</Text>
+          </ModalBody>
+
+          <ModalFooter gap={2}>
+            <Button role="link" onClick={() => navigate('/chat')} colorScheme="blue" flex={1}>
+              채팅하러 갈래요!
             </Button>
 
-            <Grid onClick={onlyReserve}>
-              <Button variant="ghost" onClick={onClose}>
-                아니요. 예약만 할게요
-              </Button>
-            </Grid>
+            <Button variant="ghost" onClick={onClose} flex={1}>
+              아니요. 예약만 할게요
+            </Button>
           </ModalFooter>
         </ModalContent>
       </Modal>

--- a/src/pages/products/[id]/page.tsx
+++ b/src/pages/products/[id]/page.tsx
@@ -1,25 +1,10 @@
 import { FC, useEffect, useState } from 'react';
-import {
-  Text,
-  Heading,
-  Box,
-  Button,
-  Avatar,
-  Flex,
-  Grid,
-  Badge,
-  Stack,
-  Modal,
-  ModalOverlay,
-  ModalContent,
-  ModalFooter,
-  ModalHeader,
-  useDisclosure,
-} from '@chakra-ui/react';
+import { Text, Heading, Box, Button, Avatar, Flex, Badge, Stack } from '@chakra-ui/react';
 import { ProductType } from '@/api/@types/@enums';
 import { MockProductDetail, mockProductDetail } from '@/api/__mock__/product';
 import { mockSimpleFiles } from '@/api/__mock__/simpleFile';
 import ImageViewer from '@/components/domains/products/ImageViewer';
+import ReservationButton from '@/components/domains/products/ReservationButton';
 
 const badgeColorschemeDict: Record<ProductType, string> = {
   [ProductType.FOOD]: 'blue',
@@ -30,8 +15,6 @@ const badgeColorschemeDict: Record<ProductType, string> = {
 const ProductDetailPage: FC = () => {
   const [productDetail, setProductDetail] = useState<MockProductDetail>();
   const [isSubscribed, setIsSubscribed] = useState<boolean>(false);
-  //const [reserve, setReserve] = useState<boolean>(false);
-  const { isOpen, onOpen, onClose } = useDisclosure();
 
   const fetchProductDetail = async () => {
     try {
@@ -52,6 +35,7 @@ const ProductDetailPage: FC = () => {
   const subscribe = () => {
     setIsSubscribed(true);
   };
+
   return (
     <Flex minHeight="inherit" flexDirection="column" justifyContent="space-between">
       <Flex flexDirection="column" padding="1.2rem 0" gap="5px">
@@ -124,28 +108,9 @@ const ProductDetailPage: FC = () => {
               {productDetail.price.toLocaleString()}원
             </Text>
           </Stack>
-          <Grid p="1.2rem 0">
-            <Button colorScheme="brand" onClick={onOpen}>
-              구매 예약 요청하기
-            </Button>
-            <Modal isOpen={isOpen} onClose={onClose}>
-              <ModalOverlay />
-              <ModalContent>
-                <ModalHeader>예약됐습니다😊 채팅으로 바로 이동할까요?</ModalHeader>
-
-                <ModalFooter>
-                  <Button colorScheme="blue" mr={3} onClick={isOpen}>
-                    채팅하러 갈래요!
-                  </Button>
-                  <Button variant="ghost" onClick={onClose}>
-                    아니요. 예약만 할게요
-                  </Button>
-                </ModalFooter>
-              </ModalContent>
-            </Modal>
-          </Grid>
         </Box>
       </Box>
+      <ReservationButton />
     </Flex>
   );
 };

--- a/src/pages/products/[id]/page.tsx
+++ b/src/pages/products/[id]/page.tsx
@@ -1,9 +1,16 @@
 import { FC, useEffect, useState } from 'react';
 import { Link } from 'react-router-dom';
 import { Text, Heading, Box, Button, Avatar, Flex, Grid, Badge, Stack } from '@chakra-ui/react';
+import { ProductType } from '@/api/@types/@enums';
 import { MockProductDetail, mockProductDetail } from '@/api/__mock__/product';
 import { mockSimpleFiles } from '@/api/__mock__/simpleFile';
 import ImageViewer from '@/components/domains/products/ImageViewer';
+
+const badgeColorschemeDict: Record<ProductType, string> = {
+  [ProductType.FOOD]: 'blue',
+  [ProductType.ACCOMMODATION]: 'yellow',
+  [ProductType.TICKET]: 'purple',
+};
 
 const ProductDetailPage: FC = () => {
   const [productDetail, setProductDetail] = useState<MockProductDetail>();
@@ -32,7 +39,7 @@ const ProductDetailPage: FC = () => {
           {productDetail.title}
         </Heading>
         <Flex alignItems="center" gap="10px">
-          <Badge fontSize="sm" variant="outline" colorScheme="brand">
+          <Badge fontSize="xl" variant="outline" colorScheme="brand">
             DEADLINE
           </Badge>
           <Text fontSize="xl">{productDetail.date} </Text>
@@ -41,8 +48,8 @@ const ProductDetailPage: FC = () => {
         <ImageViewer images={mockSimpleFiles /* TODO: API 에서 내려온 값 넣어주기 */} />
 
         <Flex alignItems="center" gap="10px" mb="5px" mt="5px">
-          <Badge fontSize="xl" colorScheme="purple">
-            Ticket
+          <Badge fontSize="xl" colorScheme={badgeColorschemeDict[productDetail.productType]}>
+            {productDetail.productType}
           </Badge>
           <Text fontSize="xl" as="b">
             {productDetail.stockName}
@@ -85,7 +92,7 @@ const ProductDetailPage: FC = () => {
               금액
             </Badge>
             <Text fontSize="xl" as="b">
-              {productDetail.price}원
+              {productDetail.price.toLocaleString()}원
             </Text>
           </Stack>
           <Link to="/.../...">

--- a/src/pages/products/[id]/page.tsx
+++ b/src/pages/products/[id]/page.tsx
@@ -65,7 +65,7 @@ const ProductDetailPage: FC = () => {
         <Text fontSize="xl">{productDetail.detail}</Text>
       </Flex>
 
-      <Box>
+      <Box mt="auto">
         {/*seller*/}
         <Flex>
           <Avatar

--- a/src/pages/products/[id]/page.tsx
+++ b/src/pages/products/[id]/page.tsx
@@ -1,4 +1,5 @@
 import { FC, useEffect, useState } from 'react';
+import { Link } from 'react-router-dom';
 import { Text, Heading, Box, Button, Avatar, Flex, Grid, Badge, Stack } from '@chakra-ui/react';
 import { MockProductDetail, mockProductDetail } from '@/api/__mock__/product';
 import { mockSimpleFiles } from '@/api/__mock__/simpleFile';
@@ -54,7 +55,11 @@ const ProductDetailPage: FC = () => {
       <Box>
         {/*seller*/}
         <Flex>
-          <Avatar size="xl" src="https://bit.ly/sage-adebayo" />
+          <Avatar
+            size="xl"
+            name={mockProductDetail.seller.nickname}
+            src={mockProductDetail.seller.profile ? mockProductDetail.seller.profile : 'https://bit.ly/broken-link'}
+          />
           <Box ml="3" w="100%">
             <Badge fontSize="xl" colorScheme="green">
               판매자
@@ -83,9 +88,11 @@ const ProductDetailPage: FC = () => {
               {productDetail.price}원
             </Text>
           </Stack>
-          <Grid p="1.2rem 0">
-            <Button colorScheme="brand">구매 예약 요청하기</Button>
-          </Grid>
+          <Link to="/.../...">
+            <Grid p="1.2rem 0">
+              <Button colorScheme="brand">구매 예약 요청하기</Button>
+            </Grid>
+          </Link>
         </Box>
       </Box>
     </Flex>

--- a/src/pages/products/[id]/page.tsx
+++ b/src/pages/products/[id]/page.tsx
@@ -6,6 +6,7 @@ import ImageViewer from '@/components/domains/products/ImageViewer';
 
 const ProductDetailPage: FC = () => {
   const [productDetail, setProductDetail] = useState<MockProductDetail>();
+  const [subscribe, setSubscribe] = useState<boolean>(false);
 
   const fetchProductDetail = async () => {
     try {
@@ -20,6 +21,10 @@ const ProductDetailPage: FC = () => {
   if (!productDetail) {
     return null;
   }
+  const onSubscribe = () => {
+    setSubscribe(prevState => !prevState);
+    toast.success('구독되었습니다');
+  };
   return (
     <Flex minHeight="inherit" flexDirection="column" justifyContent="space-between">
       <Flex flexDirection="column" padding="1.2rem 0" gap="5px">
@@ -63,8 +68,8 @@ const ProductDetailPage: FC = () => {
             </Text>
           </Box>
           <Flex align-items="center">
-            <Button colorScheme="brand" float="right">
-              판매자 구독하기
+            <Button colorScheme={subscribe ? 'brand' : 'gray'} float="right" onClick={onSubscribe}>
+              판매자{subscribe ? ' 구독하기 ' : ' 구독 취소하기'}
             </Button>
           </Flex>
         </Flex>

--- a/src/pages/products/[id]/page.tsx
+++ b/src/pages/products/[id]/page.tsx
@@ -14,6 +14,7 @@ import {
   ModalContent,
   ModalFooter,
   ModalHeader,
+  useDisclosure,
 } from '@chakra-ui/react';
 import { ProductType } from '@/api/@types/@enums';
 import { MockProductDetail, mockProductDetail } from '@/api/__mock__/product';

--- a/src/pages/products/[id]/page.tsx
+++ b/src/pages/products/[id]/page.tsx
@@ -7,7 +7,6 @@ import ImageViewer from '@/components/domains/products/ImageViewer';
 const ProductDetailPage: FC = () => {
   const [productDetail, setProductDetail] = useState<MockProductDetail>();
   const [subscribe, setSubscribe] = useState<boolean>(false);
-  const toast = useCustomToast();
 
   const fetchProductDetail = async () => {
     try {
@@ -24,7 +23,6 @@ const ProductDetailPage: FC = () => {
   }
   const onSubscribe = () => {
     setSubscribe(prevState => !prevState);
-    toast.success('구독되었습니다');
   };
   return (
     <Flex minHeight="inherit" flexDirection="column" justifyContent="space-between">

--- a/src/pages/products/[id]/page.tsx
+++ b/src/pages/products/[id]/page.tsx
@@ -14,7 +14,7 @@ const badgeColorschemeDict: Record<ProductType, string> = {
 
 const ProductDetailPage: FC = () => {
   const [productDetail, setProductDetail] = useState<MockProductDetail>();
-  const [subscribe, setSubscribe] = useState<boolean>(false);
+  const [isSubscribed, setIsSubscribed] = useState<boolean>(false);
 
   const fetchProductDetail = async () => {
     try {
@@ -29,8 +29,11 @@ const ProductDetailPage: FC = () => {
   if (!productDetail) {
     return null;
   }
-  const onSubscribe = () => {
-    setSubscribe(prevState => !prevState);
+  const cancelSubscribe = () => {
+    setIsSubscribed(false);
+  };
+  const subscribe = () => {
+    setIsSubscribed(true);
   };
   return (
     <Flex minHeight="inherit" flexDirection="column" justifyContent="space-between">
@@ -81,9 +84,16 @@ const ProductDetailPage: FC = () => {
             </Text>
           </Box>
           <Flex align-items="center">
-            <Button colorScheme={subscribe ? 'brand' : 'gray'} float="right" onClick={onSubscribe}>
-              판매자{subscribe ? ' 구독하기 ' : ' 구독 취소하기'}
-            </Button>
+            {isSubscribed && (
+              <Button colorScheme={'gray'} float="right" onClick={cancelSubscribe}>
+                판매자 구독 취소하기
+              </Button>
+            )}
+            {!isSubscribed && (
+              <Button colorScheme={'brand'} float="right" onClick={subscribe}>
+                판매자 구독하기
+              </Button>
+            )}
           </Flex>
         </Flex>
 

--- a/src/pages/products/[id]/page.tsx
+++ b/src/pages/products/[id]/page.tsx
@@ -7,6 +7,7 @@ import ImageViewer from '@/components/domains/products/ImageViewer';
 const ProductDetailPage: FC = () => {
   const [productDetail, setProductDetail] = useState<MockProductDetail>();
   const [subscribe, setSubscribe] = useState<boolean>(false);
+  const toast = useCustomToast();
 
   const fetchProductDetail = async () => {
     try {

--- a/src/pages/products/[id]/page.tsx
+++ b/src/pages/products/[id]/page.tsx
@@ -38,11 +38,13 @@ const ProductDetailPage: FC = () => {
         <Heading as="h3" size="lg">
           {productDetail.title}
         </Heading>
-        <Flex alignItems="center" gap="10px">
+        <Flex alignItems="center" gap="10px" justifyContent="right">
           <Badge fontSize="xl" variant="outline" colorScheme="brand">
             DEADLINE
           </Badge>
-          <Text fontSize="xl">{productDetail.date} </Text>
+          <Text fontSize="xl" as="b" color="brand.500">
+            {productDetail.date}{' '}
+          </Text>
         </Flex>
 
         <ImageViewer images={mockSimpleFiles /* TODO: API 에서 내려온 값 넣어주기 */} />

--- a/src/pages/products/[id]/page.tsx
+++ b/src/pages/products/[id]/page.tsx
@@ -1,6 +1,20 @@
 import { FC, useEffect, useState } from 'react';
-import { Link } from 'react-router-dom';
-import { Text, Heading, Box, Button, Avatar, Flex, Grid, Badge, Stack } from '@chakra-ui/react';
+import {
+  Text,
+  Heading,
+  Box,
+  Button,
+  Avatar,
+  Flex,
+  Grid,
+  Badge,
+  Stack,
+  Modal,
+  ModalOverlay,
+  ModalContent,
+  ModalFooter,
+  ModalHeader,
+} from '@chakra-ui/react';
 import { ProductType } from '@/api/@types/@enums';
 import { MockProductDetail, mockProductDetail } from '@/api/__mock__/product';
 import { mockSimpleFiles } from '@/api/__mock__/simpleFile';
@@ -15,6 +29,8 @@ const badgeColorschemeDict: Record<ProductType, string> = {
 const ProductDetailPage: FC = () => {
   const [productDetail, setProductDetail] = useState<MockProductDetail>();
   const [isSubscribed, setIsSubscribed] = useState<boolean>(false);
+  //const [reserve, setReserve] = useState<boolean>(false);
+  const { isOpen, onOpen, onClose } = useDisclosure();
 
   const fetchProductDetail = async () => {
     try {
@@ -107,11 +123,26 @@ const ProductDetailPage: FC = () => {
               {productDetail.price.toLocaleString()}원
             </Text>
           </Stack>
-          <Link to="/.../...">
-            <Grid p="1.2rem 0">
-              <Button colorScheme="brand">구매 예약 요청하기</Button>
-            </Grid>
-          </Link>
+          <Grid p="1.2rem 0">
+            <Button colorScheme="brand" onClick={onOpen}>
+              구매 예약 요청하기
+            </Button>
+            <Modal isOpen={isOpen} onClose={onClose}>
+              <ModalOverlay />
+              <ModalContent>
+                <ModalHeader>예약됐습니다😊 채팅으로 바로 이동할까요?</ModalHeader>
+
+                <ModalFooter>
+                  <Button colorScheme="blue" mr={3} onClick={isOpen}>
+                    채팅하러 갈래요!
+                  </Button>
+                  <Button variant="ghost" onClick={onClose}>
+                    아니요. 예약만 할게요
+                  </Button>
+                </ModalFooter>
+              </ModalContent>
+            </Modal>
+          </Grid>
         </Box>
       </Box>
     </Flex>

--- a/src/pages/products/seller/page.tsx
+++ b/src/pages/products/seller/page.tsx
@@ -1,4 +1,4 @@
-import { FC, useEffect } from 'react';
+import { FC } from 'react';
 import {
   Flex,
   Input,
@@ -18,16 +18,6 @@ import {
 import ImageUploader from '@/components/domains/products/ImageUploader';
 
 const ProductRegistrationPage: FC = () => {
-  const FetchSellerServer = async () => {
-    try {
-      setMockData(MockData);
-    } catch (e) {}
-  };
-
-  useEffect(() => {
-    FetchSellerServer();
-  });
-
   return (
     <Flex flexDirection="column" padding="1.2rem 0" gap="20px">
       <Flex>

--- a/src/pages/products/seller/page.tsx
+++ b/src/pages/products/seller/page.tsx
@@ -1,4 +1,4 @@
-import { FC, useEffect, useState } from 'react';
+import { FC, useEffect } from 'react';
 import {
   Flex,
   Input,
@@ -15,12 +15,9 @@ import {
   Divider,
 } from '@chakra-ui/react';
 
-import { MockProduct } from '@/api/__mock__/mockProduct';
 import ImageUploader from '@/components/domains/products/ImageUploader';
 
 const ProductRegistrationPage: FC = () => {
-  const [MockData, setMockData] = useState<MockProduct>();
-
   const FetchSellerServer = async () => {
     try {
       setMockData(MockData);


### PR DESCRIPTION
## Type
- [X] Feature
- [ ] Fix

<!-- Jira Ticket - If the issue does not exist, remove it. -->
Implements [issue SU-129](https://geezers-io.atlassian.net/browse/SU-129)

## What & Why

- 판매자 프로필 사진 **미등록** 시 차크라 아바타 컴포넌트를 이용해 **임시 이름을 이용한 프로필 사진으로 등록 될 수 있게** 만들었습니다.
- **'판매자 구독 버튼'** 을 통해 판매자 구독 기능을 할 수 있는 버튼을 구현했습니다.
- 재고 종류에 따라 **재고 타입 뱃지의 스타일을 지정**했습니다. 

- [x] (**구현 완료**)  '구매 예약 요청하기' 버튼을 클릭 시 예약이 확정(?)되고 사용자가 채팅으로 이동하게끔 의사를 물은 후 채팅화면으로 전환될 수 있게 만들 예정입니다. 
- **재고 금액을 문자열로** 바꿨습니다.
- 다른 건 기억이 안납니다.

## Checklist
- [X] 지라 티켓이 있다면 이슈 번호를 매핑하셨나요?
