### PR TITLE
feat: Main page API integration

### DIFF
--- a/src/pages/page.tsx
+++ b/src/pages/page.tsx
@@ -3,7 +3,7 @@ import { Fire } from 'react-bootstrap-icons';
 import { Link } from 'react-router-dom';
 import { Box, Button, Flex, Heading, Spacer, Text } from '@chakra-ui/react';
 import { useTheme } from '@emotion/react';
-import { GetMainPageProductsResponse } from '@/api/@types/Products';
+import { Distance, GetMainPageProductsResponse } from '@/api/@types/Products';
 import { ProductsService } from '@/api/services/Products';
 import ProductCards from '@/components/domains/products/ProductCards';
 import ImageSlider from '@/components/shared/ImageCarousel';
@@ -11,27 +11,12 @@ import { useCustomToast } from '@/hooks/useCustomToast';
 import { useBoundedStore } from '@/stores';
 import { pick } from '@/utils/object';
 
-interface DistanceEnumType {
-  ONE: number;
-  THREE: number;
-  FIVE: number;
-  TEN: number;
-}
-
-const DistanceEnum: DistanceEnumType = {
-  ONE: 1,
-  THREE: 3,
-  FIVE: 5,
-  TEN: 10,
-};
-
 const IndexPage: FC = () => {
   const theme = useTheme();
   const [products, setProducts] = useState<GetMainPageProductsResponse>();
   const [bannerImages, setBannerImages] = useState<string[]>([]);
   const toast = useCustomToast();
   const geo = useBoundedStore(state => state.geo);
-  const distanceValue = DistanceEnum.THREE;
 
   const fetchDataFromAPI = async () => {
     try {
@@ -138,7 +123,7 @@ const IndexPage: FC = () => {
       {products?.myNeighborhoods && (
         <>
           <Spacer h={8} />
-          <Link to={`/products?distance=${distanceValue}`}>
+          <Link to={`/products?distance=${Distance}`}>
             <Flex
               flexDirection="column"
               alignItems="center"

--- a/src/pages/page.tsx
+++ b/src/pages/page.tsx
@@ -11,12 +11,27 @@ import { useCustomToast } from '@/hooks/useCustomToast';
 import { useBoundedStore } from '@/stores';
 import { pick } from '@/utils/object';
 
+interface DistanceEnumType {
+  ONE: number;
+  THREE: number;
+  FIVE: number;
+  TEN: number;
+}
+
+const DistanceEnum: DistanceEnumType = {
+  ONE: 1,
+  THREE: 3,
+  FIVE: 5,
+  TEN: 10,
+};
+
 const IndexPage: FC = () => {
   const theme = useTheme();
   const [products, setProducts] = useState<GetMainPageProductsResponse>();
   const [bannerImages, setBannerImages] = useState<string[]>([]);
   const toast = useCustomToast();
   const geo = useBoundedStore(state => state.geo);
+  const distanceValue = DistanceEnum.THREE;
 
   const fetchDataFromAPI = async () => {
     try {
@@ -123,7 +138,7 @@ const IndexPage: FC = () => {
       {products?.myNeighborhoods && (
         <>
           <Spacer h={8} />
-          <Link to={`/products?distance=${3}`}>
+          <Link to={`/products?distance=${distanceValue}`}>
             <Flex
               flexDirection="column"
               alignItems="center"

--- a/src/pages/page.tsx
+++ b/src/pages/page.tsx
@@ -16,11 +16,11 @@ const IndexPage: FC = () => {
   const [products, setProducts] = useState<GetMainPageProductsResponse>();
   const [bannerImages, setBannerImages] = useState<string[]>([]);
   const toast = useCustomToast();
-  const geoLocation = useBoundedStore(state => state.geoLocation);
+  const geo = useBoundedStore(state => state.geoLocation);
 
   const fetchDataFromAPI = async () => {
     try {
-      const response = await ProductsService.getMainPageList(pick(geoLocation, ['latitude', 'longitude']));
+      const response = await ProductsService.getMainPageList(pick(geo, ['latitude', 'longitude']));
       setProducts(response);
     } catch (e) {
       toast.error(e);

--- a/src/pages/page.tsx
+++ b/src/pages/page.tsx
@@ -16,7 +16,7 @@ const IndexPage: FC = () => {
   const [products, setProducts] = useState<GetMainPageProductsResponse>();
   const [bannerImages, setBannerImages] = useState<string[]>([]);
   const toast = useCustomToast();
-  const geo = useBoundedStore(state => state.geoLocation);
+  const geo = useBoundedStore(state => state.geo);
 
   const fetchDataFromAPI = async () => {
     try {

--- a/src/pages/page.tsx
+++ b/src/pages/page.tsx
@@ -123,7 +123,7 @@ const IndexPage: FC = () => {
       {products?.myNeighborhoods && (
         <>
           <Spacer h={8} />
-          <Link to={`/products?distance=${Distance}`}>
+          <Link to={`/products?distance=${Distance.Three}`}>
             <Flex
               flexDirection="column"
               alignItems="center"

--- a/src/pages/page.tsx
+++ b/src/pages/page.tsx
@@ -1,7 +1,7 @@
 import { FC, useEffect, useState } from 'react';
 import { Fire } from 'react-bootstrap-icons';
 import { Link } from 'react-router-dom';
-import { Box, Button, Flex, Heading, Spacer, Text } from '@chakra-ui/react';
+import { Box, Button, Flex, Heading, Spacer, Text, LinkOverlay } from '@chakra-ui/react';
 import { useTheme } from '@emotion/react';
 import { GetMainPageProductsResponse } from '@/api/@types/Products';
 import { ProductsService } from '@/api/services/Products';
@@ -71,7 +71,7 @@ const IndexPage: FC = () => {
         uniqueKey="aiRecommended"
         products={products?.aiRecommends}
         emptyComment="아직 추천된 재고가 없어요 :("
-        linkTo={id => `/.../${id}` /* TODO: Routing to detail page */}
+        linkTo={id => `/products/${id}`}
         mockCount={4}
       />
 
@@ -82,7 +82,7 @@ const IndexPage: FC = () => {
         uniqueKey="myNeighborhoods"
         products={products?.myNeighborhoods}
         emptyComment="아직 마감 임박된 재고가 없어요 :("
-        linkTo={id => `/.../${id}` /* TODO: Routing to detail page */}
+        linkTo={id => `/products/${id}`}
         showDistance={false}
         mockCount={4}
       />
@@ -116,14 +116,14 @@ const IndexPage: FC = () => {
         uniqueKey="myNeighborhoods"
         products={products?.myNeighborhoods}
         emptyComment="근처에 있는 재고가 없어요 :("
-        linkTo={id => `/.../${id}` /* TODO: Routing to detail */}
+        linkTo={id => `/products/${id}`}
         showExpiredAt={false}
         mockCount={4}
       />
       {products?.myNeighborhoods && (
         <>
           <Spacer h={8} />
-          <Link to="..." /* TODO: Routing to list page with filter */>
+          <LinkOverlay as={Link} to="/products">
             <Flex
               flexDirection="column"
               alignItems="center"
@@ -139,7 +139,7 @@ const IndexPage: FC = () => {
                 재고 더 보기
               </Button>
             </Flex>
-          </Link>
+          </LinkOverlay>
         </>
       )}
 
@@ -150,7 +150,7 @@ const IndexPage: FC = () => {
           더 많은 정보를 확인하세요!
         </Heading>
         <Spacer h={6} flex="unset" />
-        <Link to="..." /* TODO: Routing to list page without filter */>
+        <Link to="/products">
           <Button colorScheme="brand" size="lg" tabIndex={-1}>
             모든 재고 둘러보기
           </Button>

--- a/src/pages/page.tsx
+++ b/src/pages/page.tsx
@@ -89,7 +89,7 @@ const IndexPage: FC = () => {
       {products?.myNeighborhoods && (
         <>
           <Spacer h={8} />
-          <Link to="..." /* TODO: Routing to list page with filter */>
+          <Link to="/products">
             <Flex
               flexDirection="column"
               alignItems="center"

--- a/src/pages/page.tsx
+++ b/src/pages/page.tsx
@@ -1,7 +1,7 @@
 import { FC, useEffect, useState } from 'react';
 import { Fire } from 'react-bootstrap-icons';
 import { Link } from 'react-router-dom';
-import { Box, Button, Flex, Heading, Spacer, Text, LinkOverlay } from '@chakra-ui/react';
+import { Box, Button, Flex, Heading, Spacer, Text } from '@chakra-ui/react';
 import { useTheme } from '@emotion/react';
 import { GetMainPageProductsResponse } from '@/api/@types/Products';
 import { ProductsService } from '@/api/services/Products';
@@ -123,7 +123,7 @@ const IndexPage: FC = () => {
       {products?.myNeighborhoods && (
         <>
           <Spacer h={8} />
-          <LinkOverlay as={Link} to="/products">
+          <Link to={`/products?distance=${3}`}>
             <Flex
               flexDirection="column"
               alignItems="center"
@@ -139,7 +139,7 @@ const IndexPage: FC = () => {
                 재고 더 보기
               </Button>
             </Flex>
-          </LinkOverlay>
+          </Link>
         </>
       )}
 


### PR DESCRIPTION
## Type
- [x] Feature
- [x] Fix

<!-- Jira Ticket - If the issue does not exist, remove it. -->
Implements [issue SU-65](https://geezers-io.atlassian.net/browse/SU-65)

## What & Why
<!-- 무엇을 작업하셨나요? -->
<!-- 수정이라면, 어떤 이유로 수정되었나요? -->
Index 페이지는 메인 화면을 표시하며, API와의 연동이 주된 목적입니다.

- 메인 페이지에서 필요한 데이터를 비동기적으로 가져오는 데 사용됩니다. 성공적으로 데이터를 가져오면 메인 페이지에서 해당 데이터를 활용하여 사용자에게 보여줄 수 있게 됩니다.

fetchDataFromAPI 함수는 메인 페이지에서 필요한 데이터를 가져오는 데 사용합니다. 

- ProductsService.getMainPageList를 호출하여 API로부터 데이터를 가져옵니다.

- pick 함수를 사용하여 geoLocation에서 필요한 데이터만 추출하여 API 요청에 전달합니다.

- API 요청이 성공하면 반환된 데이터를 setProducts를 통해 상태에 설정하여 페이지에서 사용할 수 있도록 합니다.

ㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡㅡ


## Checklist
- [x] 지라 티켓이 있다면 이슈 번호를 매핑하셨나요?
