### PR TITLE
feat: 애플리케이션 웹소켓 객체 초기화 기능 / 객체 접근 유틸 훅 작성

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@chakra-ui/react": "^2.8.1",
         "@emotion/react": "^11.11.1",
         "@emotion/styled": "^11.11.0",
+        "@stomp/stompjs": "^7.0.0",
         "axios": "^1.5.1",
         "dayjs": "^1.11.10",
         "formik": "^2.4.5",
@@ -2629,6 +2630,11 @@
       "engines": {
         "node": ">=14.0.0"
       }
+    },
+    "node_modules/@stomp/stompjs": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@stomp/stompjs/-/stompjs-7.0.0.tgz",
+      "integrity": "sha512-fGdq4wPDnSV/KyOsjq4P+zLc8MFWC3lMmP5FBgLWKPJTYcuCbAIrnRGjB7q2jHZdYCOD5vxLuFoKIYLy5/u8Pw=="
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.3",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "@chakra-ui/react": "^2.8.1",
     "@emotion/react": "^11.11.1",
     "@emotion/styled": "^11.11.0",
+    "@stomp/stompjs": "^7.0.0",
     "axios": "^1.5.1",
     "dayjs": "^1.11.10",
     "formik": "^2.4.5",

--- a/src/hooks/useStompSocket.tsx
+++ b/src/hooks/useStompSocket.tsx
@@ -3,7 +3,7 @@ import { User } from '@/api/@types/Auth';
 import { useCustomToast } from '@/hooks/useCustomToast';
 import { useBoundedStore } from '@/stores';
 
-const SOCKET_URL = 'ws://galaxy4276.asuscomm.com:8081/api/ws';
+const SOCKET_URL = 'ws://localhost:8081/api/ws';
 
 const useStompSocket = () => {
   const { user, client, setClient } = useBoundedStore(({ user, client, setClient }) => ({

--- a/src/pages/auth/sign-in/page.tsx
+++ b/src/pages/auth/sign-in/page.tsx
@@ -8,6 +8,7 @@ import { useCustomToast } from '@/hooks/useCustomToast';
 import { useRedirect } from '@/hooks/useRedirect';
 import { useBoundedStore } from '@/stores';
 import { pick } from '@/utils/object';
+import useStompSocket from '@/utils/useStompSocket';
 
 const popupDefaultSize: Record<AuthVendor, { width: number; height: number }> = {
   [AuthVendor.GOOGLE]: { width: 485, height: 710 },
@@ -17,6 +18,7 @@ const popupDefaultSize: Record<AuthVendor, { width: number; height: number }> = 
 
 const SignInPage: FC = () => {
   const setUser = useBoundedStore(state => state.setUser);
+  const { connect } = useStompSocket();
   const toast = useCustomToast();
   const popupWindow = useRef<Window | null>(null);
   const { redirect, navigateWithRedirectPath } = useRedirect();
@@ -36,6 +38,7 @@ const SignInPage: FC = () => {
       }
 
       setUser(res.user);
+      connect(res.user);
       redirect();
     } catch (e) {
       toast.error(e);

--- a/src/pages/auth/sign-in/page.tsx
+++ b/src/pages/auth/sign-in/page.tsx
@@ -6,9 +6,9 @@ import OAuthButton from '@/components/domains/auth/OAuthButton';
 import { AUTH_VENDOR_LABEL } from '@/constants/labels';
 import { useCustomToast } from '@/hooks/useCustomToast';
 import { useRedirect } from '@/hooks/useRedirect';
+import useStompSocket from '@/hooks/useStompSocket';
 import { useBoundedStore } from '@/stores';
 import { pick } from '@/utils/object';
-import useStompSocket from '@/utils/useStompSocket';
 
 const popupDefaultSize: Record<AuthVendor, { width: number; height: number }> = {
   [AuthVendor.GOOGLE]: { width: 485, height: 710 },

--- a/src/pages/page.tsx
+++ b/src/pages/page.tsx
@@ -8,9 +8,12 @@ import { mockProducts } from '@/api/__mock__/mockProduct';
 import ProductCards from '@/components/domains/products/ProductCards';
 import ImageSlider from '@/components/shared/ImageCarousel';
 import { delay } from '@/utils/delay';
+import useStompSocket from '@/utils/useStompSocket';
 
 const IndexPage: FC = () => {
   const theme = useTheme();
+  useStompSocket(); // WebSocket Lazy Initialization
+
   const [recommendedProducts, setRecommendedProducts] = useState<ProductSummary[]>();
   const [nearExpirationProducts, setNearExpirationProducts] = useState<ProductSummary[]>();
   const [nearProducts, setNearProducts] = useState<ProductSummary[]>();

--- a/src/pages/page.tsx
+++ b/src/pages/page.tsx
@@ -8,11 +8,9 @@ import { mockProducts } from '@/api/__mock__/mockProduct';
 import ProductCards from '@/components/domains/products/ProductCards';
 import ImageSlider from '@/components/shared/ImageCarousel';
 import { delay } from '@/utils/delay';
-import useStompSocket from '@/utils/useStompSocket';
 
 const IndexPage: FC = () => {
   const theme = useTheme();
-  useStompSocket(); // WebSocket Lazy Initialization
 
   const [recommendedProducts, setRecommendedProducts] = useState<ProductSummary[]>();
   const [nearExpirationProducts, setNearExpirationProducts] = useState<ProductSummary[]>();

--- a/src/stores/index.ts
+++ b/src/stores/index.ts
@@ -1,14 +1,18 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 import { createGeoSlice, GeoSlice } from '@/stores/geo';
+import { createSocketSlice, SocketSlice } from '@/stores/socket';
 import { createUserSlice, UserSlice } from '@/stores/user';
 import { pick } from '@/utils/object';
 
-export const useBoundedStore = create<UserSlice & GeoSlice>()(
+type Slices = UserSlice & GeoSlice & SocketSlice;
+
+export const useBoundedStore = create<Slices>()(
   persist(
     (...args) => ({
       ...createUserSlice(...args),
       ...createGeoSlice(...args),
+      ...createSocketSlice(...args),
     }),
     {
       name: 'bounded-store',

--- a/src/stores/socket.ts
+++ b/src/stores/socket.ts
@@ -1,0 +1,12 @@
+import type { Client } from '@stomp/stompjs';
+import { StateCreator } from 'zustand/esm/vanilla';
+
+export type SocketSlice = {
+  client?: Client;
+  setClient: (c: Client) => void;
+};
+
+export const createSocketSlice: StateCreator<SocketSlice, [], [], SocketSlice> = set => ({
+  client: undefined,
+  setClient: client => set({ client }),
+});

--- a/src/utils/useStompSocket.tsx
+++ b/src/utils/useStompSocket.tsx
@@ -3,7 +3,7 @@ import { User } from '@/api/@types/Auth';
 import { useCustomToast } from '@/hooks/useCustomToast';
 import { useBoundedStore } from '@/stores';
 
-const SOCKET_URL = 'ws://localhost:8081/api/ws';
+const SOCKET_URL = 'ws://galaxy4276.asuscomm.com:8081/api/ws';
 
 const useStompSocket = () => {
   const { user, client, setClient } = useBoundedStore(({ user, client, setClient }) => ({

--- a/src/utils/useStompSocket.tsx
+++ b/src/utils/useStompSocket.tsx
@@ -1,0 +1,53 @@
+import { useEffect } from 'react';
+import { Client } from '@stomp/stompjs';
+import { useCustomToast } from '@/hooks/useCustomToast';
+import { useBoundedStore } from '@/stores';
+
+const SOCKET_URL = 'ws://localhost:8081/api/ws';
+
+const useStompSocket = () => {
+  const { user, client, setClient } = useBoundedStore(({ user, client, setClient }) => ({
+    user,
+    client,
+    setClient,
+  }));
+  const { info } = useCustomToast();
+
+  useEffect(() => {
+    if (!user) {
+      throw Error('로그인이 필요합니다.');
+    }
+
+    // 객체 초기화(소켓 연결) 수행
+    if (!client) {
+      const headers = {
+        userId: String(user.id),
+        phone: user.phone,
+      };
+      const client = new Client({
+        brokerURL: SOCKET_URL,
+        connectHeaders: headers,
+        onConnect: () => {
+          console.debug('소켓 커넥션이 수행됨');
+          client.subscribe(
+            `/topic/alert/${user.id}`,
+            o => {
+              info(o.body);
+            },
+            headers,
+          );
+        },
+        onStompError: frame => {
+          console.error('stomp 에러 발생');
+          console.log(frame.body);
+        },
+      });
+      client.activate();
+      setClient(client);
+    }
+  }, [client, user]);
+
+  return client;
+};
+
+export default useStompSocket;


### PR DESCRIPTION
## Type
- [X] Feature
- [ ] Fix

## What & Why
웹소켓에 대한 외부 상태를 작성하고 애플리케이션에 반영하였습니다. (with zustand)
웹소켓이 연결되어야하는 시점에 연결 객체 초기화를 수행할 수 있는 수동적인 방법을 제공합니다.
웹소켓 객체는 단 한번만 초기화를 수행할 수 있습니다. (해당 객체는 싱글톤처럼 동작합니다.)

## Checklist
- [ ] 지라 티켓이 있다면 이슈 번호를 매핑하셨나요?
